### PR TITLE
feat[#4]: 공통 예외 처리 구조 추가

### DIFF
--- a/src/main/java/com/chanhk/pupildilation/global/exception/BusinessException.java
+++ b/src/main/java/com/chanhk/pupildilation/global/exception/BusinessException.java
@@ -1,4 +1,13 @@
 package com.chanhk.pupildilation.global.exception;
 
-public class BusinessException {
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/chanhk/pupildilation/global/exception/BusinessException.java
+++ b/src/main/java/com/chanhk/pupildilation/global/exception/BusinessException.java
@@ -1,0 +1,4 @@
+package com.chanhk.pupildilation.global.exception;
+
+public class BusinessException {
+}

--- a/src/main/java/com/chanhk/pupildilation/global/exception/ErrorCode.java
+++ b/src/main/java/com/chanhk/pupildilation/global/exception/ErrorCode.java
@@ -1,0 +1,4 @@
+package com.chanhk.pupildilation.global.exception;
+
+public enum ErrorCode {
+}

--- a/src/main/java/com/chanhk/pupildilation/global/exception/ErrorCode.java
+++ b/src/main/java/com/chanhk/pupildilation/global/exception/ErrorCode.java
@@ -1,4 +1,17 @@
 package com.chanhk.pupildilation.global.exception;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
 public enum ErrorCode {
+    // Common
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C00", "입력값이 올바르지 않습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C01", "서버 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/chanhk/pupildilation/global/exception/ErrorResponse.java
+++ b/src/main/java/com/chanhk/pupildilation/global/exception/ErrorResponse.java
@@ -1,4 +1,18 @@
 package com.chanhk.pupildilation.global.exception;
 
+import lombok.Getter;
+
+@Getter
 public class ErrorResponse {
+    private String code;
+    private String message;
+
+    private ErrorResponse(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
 }

--- a/src/main/java/com/chanhk/pupildilation/global/exception/ErrorResponse.java
+++ b/src/main/java/com/chanhk/pupildilation/global/exception/ErrorResponse.java
@@ -1,0 +1,4 @@
+package com.chanhk.pupildilation.global.exception;
+
+public class ErrorResponse {
+}

--- a/src/main/java/com/chanhk/pupildilation/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chanhk/pupildilation/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,4 @@
+package com.chanhk.pupildilation.global.exception;
+
+public class GlobalExceptionHandler {
+}

--- a/src/main/java/com/chanhk/pupildilation/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chanhk/pupildilation/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,32 @@
 package com.chanhk.pupildilation.global.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+    // business exception 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> businessExceptionHandler(BusinessException e) {
+        return createResponseEntity(e.getErrorCode());
+    }
+
+    // @Valid 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        return createResponseEntity(ErrorCode.INVALID_INPUT_VALUE);
+    }
+
+    // 나머지 예상 못한 예외 (500)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return createResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse> createResponseEntity(ErrorCode errorCode) {
+        return new ResponseEntity<>(ErrorResponse.of(errorCode), errorCode.getHttpStatus());
+    }
 }


### PR DESCRIPTION
- `ErrorCode` enum은 필요할 때마다 추가할 것
    - `status` : http status 정의
    - `code` : 내부적으로(프론트랑) 사용할 코드
    - `message` : 에러 메시지
- `ErrorResponse`
    - `ErrorResponse.of(code, message)` 는 필요없어서 제거함
    → `@AllArgsConstructor` 도 필요없음
- `GlobalExceptionHandler`
    - `createResponseEntity()` 로 응답 생성 로직 분리 → 핸들러 메서드가 단순해짐
    - `BusinessException` 하나로 모든 비즈니스 예외를 처리하는 구조 명확
    - `@Valid`  실패 시 `ErrorCode.INVALID_INPUT_VALUE`  뱉게 구현
    - 남은 예상 못한 예외 → `ErrorCode.INTERNAL_SERVER_ERROR`