### PR TITLE
build: #35 Flyway DB 마이그레이션 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 
     // DB
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-flyway'
+    implementation 'org.flywaydb:flyway-mysql'
 }
 
 test {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,9 +5,13 @@ spring:
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
   jpa:
     hibernate:
-      ddl-auto: update            # 로컬은 update로 편하게
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
@@ -23,7 +27,7 @@ logging:
   level:
     com.chanhk.pupildilation: DEBUG
     org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE  # 바인딩 파라미터 출력
+org.hibernate.orm.jdbc.bind: TRACE  # 바인딩 파라미터 출력
 
 # Mock 결제 사용 (토스 연동 X)
 payment:

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,147 @@
+CREATE TABLE users
+(
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    email      VARCHAR(100) NOT NULL,
+    password   VARCHAR(255) NOT NULL,
+    name       VARCHAR(50)  NOT NULL,
+    role       VARCHAR(20)  NOT NULL,
+    created_at DATETIME(6)  NOT NULL,
+    updated_at DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_users_email UNIQUE (email)
+);
+
+CREATE TABLE clubs
+(
+    id          BIGINT      NOT NULL AUTO_INCREMENT,
+    user_id     BIGINT      NOT NULL,
+    name        VARCHAR(100) NOT NULL,
+    description TEXT,
+    status      VARCHAR(20) NOT NULL,
+    created_at  DATETIME(6) NOT NULL,
+    updated_at  DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_clubs_user FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE venues
+(
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    name       VARCHAR(100) NOT NULL,
+    address    VARCHAR(255),
+    created_at DATETIME(6)  NOT NULL,
+    updated_at DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE events
+(
+    id                   BIGINT       NOT NULL AUTO_INCREMENT,
+    club_id              BIGINT,
+    venue_id             BIGINT,
+    name                 VARCHAR(200) NOT NULL,
+    description          TEXT,
+    event_at             DATETIME(6)  NOT NULL,
+    booking_open_at      DATETIME(6)  NOT NULL,
+    booking_close_at     DATETIME(6)  NOT NULL,
+    cancel_deadline_days INT          NOT NULL DEFAULT 3,
+    max_seats_per_user   INT          NOT NULL DEFAULT 4,
+    created_at           DATETIME(6)  NOT NULL,
+    updated_at           DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_events_club FOREIGN KEY (club_id) REFERENCES clubs (id),
+    CONSTRAINT fk_events_venue FOREIGN KEY (venue_id) REFERENCES venues (id)
+);
+
+CREATE TABLE seats
+(
+    id         BIGINT      NOT NULL AUTO_INCREMENT,
+    venue_id   BIGINT,
+    section    VARCHAR(20) NOT NULL,
+    row_num    INT         NOT NULL,
+    number     INT         NOT NULL,
+    seat_type  VARCHAR(20) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_seat_venue_section_row_number UNIQUE (venue_id, section, row_num, number),
+    CONSTRAINT fk_seats_venue FOREIGN KEY (venue_id) REFERENCES venues (id)
+);
+
+CREATE TABLE event_seats
+(
+    id         BIGINT      NOT NULL AUTO_INCREMENT,
+    event_id   BIGINT,
+    seat_id    BIGINT,
+    price      INT         NOT NULL,
+    status     VARCHAR(20) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_event_seat_event_id_seat_id UNIQUE (event_id, seat_id),
+    CONSTRAINT fk_event_seats_event FOREIGN KEY (event_id) REFERENCES events (id),
+    CONSTRAINT fk_event_seats_seat FOREIGN KEY (seat_id) REFERENCES seats (id)
+);
+
+CREATE TABLE reservations
+(
+    id          BIGINT      NOT NULL AUTO_INCREMENT,
+    user_id     BIGINT,
+    event_id    BIGINT,
+    status      VARCHAR(20) NOT NULL,
+    reserved_at DATETIME(6) NOT NULL,
+    canceled_at DATETIME(6),
+    created_at  DATETIME(6) NOT NULL,
+    updated_at  DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_reservations_user FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_reservations_event FOREIGN KEY (event_id) REFERENCES events (id)
+);
+
+CREATE TABLE reservation_seats
+(
+    id            BIGINT      NOT NULL AUTO_INCREMENT,
+    reservation_id BIGINT,
+    event_seat_id  BIGINT,
+    created_at    DATETIME(6) NOT NULL,
+    updated_at    DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_reservation_seat_event_seat_id UNIQUE (event_seat_id),
+    CONSTRAINT fk_reservation_seats_reservation FOREIGN KEY (reservation_id) REFERENCES reservations (id),
+    CONSTRAINT fk_reservation_seats_event_seat FOREIGN KEY (event_seat_id) REFERENCES event_seats (id)
+);
+
+CREATE TABLE payments
+(
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    reservation_id BIGINT,
+    order_id       VARCHAR(100) NOT NULL,
+    payment_key    VARCHAR(200),
+    mid            VARCHAR(50),
+    method         VARCHAR(50),
+    total_amount   INT          NOT NULL,
+    status         VARCHAR(20)  NOT NULL,
+    requested_at   DATETIME(6)  NOT NULL,
+    approved_at    DATETIME(6),
+    created_at     DATETIME(6)  NOT NULL,
+    updated_at     DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_payments_reservation_id UNIQUE (reservation_id),
+    CONSTRAINT uk_payments_order_id UNIQUE (order_id),
+    CONSTRAINT fk_payments_reservation FOREIGN KEY (reservation_id) REFERENCES reservations (id)
+);
+
+CREATE TABLE refunds
+(
+    id            BIGINT      NOT NULL AUTO_INCREMENT,
+    payment_id    BIGINT,
+    refund_amount INT         NOT NULL,
+    reason        VARCHAR(255),
+    status        VARCHAR(20) NOT NULL,
+    refunded_at   DATETIME(6),
+    created_at    DATETIME(6) NOT NULL,
+    updated_at    DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_refunds_payment_id UNIQUE (payment_id),
+    CONSTRAINT fk_refunds_payment FOREIGN KEY (payment_id) REFERENCES payments (id)
+);


### PR DESCRIPTION
## 개요
Hibernate `ddl-auto: update` 대신 Flyway로 DB 스키마를 버전 관리하도록 설정합니다.

## 변경 파일
- `build.gradle` — `spring-boot-flyway`, `flyway-mysql` 의존성 추가
- `src/main/resources/application-dev.yml` — `ddl-auto: validate` 변경, Flyway 설정 추가
- `src/main/resources/db/migration/V1__init.sql` — 전체 테이블 초기 생성 스크립트 (clubs.user_id FK 포함)

## 리뷰 포인트
- `V1__init.sql` 스키마가 각 엔티티 클래스와 일치하는지 확인
- `clubs.user_id` FK 제약 조건 (`fk_clubs_user`) 정상 적용 여부
- Spring Boot 4.x 환경에서 `spring-boot-flyway` 별도 모듈 필요 여부 확인

Closes #35